### PR TITLE
feat: improve auto reconnect and measurement controls

### DIFF
--- a/BLEUnity/Assets/Scripts/BLEManager.cs
+++ b/BLEUnity/Assets/Scripts/BLEManager.cs
@@ -14,13 +14,37 @@ public class BLEManager : MonoBehaviour
 
     [SerializeField] private Button startScan;
     [SerializeField] private Button stopScan;
+    [SerializeField] private UI_BLEToast toast;
+
+    [Header("Scanning")]
+    [SerializeField, Tooltip("Duration of the automatic scan that runs on launch (seconds).")]
+    private float autoScanDurationSeconds = 8f;
+    [SerializeField, Tooltip("Duration of a manual scan triggered from the UI (seconds).")]
+    private float manualScanDurationSeconds = 12f;
+    [SerializeField, Tooltip("Duration of the recovery scan kicked off after resume/disconnect (seconds).")]
+    private float resumeScanDurationSeconds = 6f;
+    [SerializeField, Tooltip("Automatically reconnect to devices that were previously trusted.")]
+    private bool autoReconnectEnabled = true;
+
+    public event Action<bool, float> ScanStateChanged;
+    public event Action<BleDevice, MeasurementState> MeasurementStateChanged;
+    public bool IsScanning => isScanning;
 
 
+    private const string AutoReconnectPrefsKey = "ble.autoReconnect.enabled";
+    private const float AutoReconnectTimeoutSeconds = 15f;
     // All discovered or connected devices
     private readonly Dictionary<string, BleDevice> devices = new();
     public IReadOnlyDictionary<string, BleDevice> Devices => devices;
 
     private readonly Dictionary<string, List<IBLEDeviceListener>> listeners = new();
+    private readonly HashSet<string> pendingAutoConnections = new();
+    private readonly HashSet<string> userRequestedDisconnects = new();
+    private readonly Dictionary<string, Coroutine> autoReconnectTimeouts = new();
+    private Coroutine trustedDiscoveryRoutine;
+
+    private Coroutine scanRoutine;
+    private bool isScanning;
 
     private void Awake()
     {
@@ -28,6 +52,9 @@ public class BLEManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
+            autoReconnectEnabled = PlayerPrefs.GetInt(
+                AutoReconnectPrefsKey,
+                autoReconnectEnabled ? 1 : 0) == 1;
         }
         else
         {
@@ -37,8 +64,13 @@ public class BLEManager : MonoBehaviour
 
     private IEnumerator Start()
     {
-        startScan.onClick.AddListener(() => BLEPlugin.Instance.StartScan());
-        stopScan.onClick.AddListener(() => BLEPlugin.Instance.StopScan());
+        startScan.onClick.AddListener(OnStartScanPressed);
+        stopScan.onClick.AddListener(OnStopScanPressed);
+
+        if (toast == null)
+            toast = UI_BLEToast.Instance;
+
+        SetScanState(false, 0f);
 
         // 1. Request BLE permissions
         BLEPlugin.Instance.RequestPermissions();
@@ -46,6 +78,120 @@ public class BLEManager : MonoBehaviour
 
         // 2. Initialize native BLE
         BLEPlugin.Instance.Init();
+
+        // Kick off an automatic discovery scan so the device list is pre-populated.
+        if (autoScanDurationSeconds > 0f)
+        {
+            BeginScan(autoScanDurationSeconds);
+        }
+    }
+
+    private void OnApplicationPause(bool pause)
+    {
+        if (pause)
+        {
+            Debug.Log("[BLEManager] Application paused. Suspending scans and pausing measurements.");
+            StopActiveScan();
+
+            foreach (var device in devices.Values)
+            {
+                if (device.isConnected)
+                {
+                    PauseMeasurement(device.id);
+                }
+            }
+        }
+        else if (autoReconnectEnabled)
+        {
+            Debug.Log("[BLEManager] Application resumed. Launching quick discovery scan.");
+            BeginScan(resumeScanDurationSeconds);
+        }
+        else
+        {
+            Debug.Log("[BLEManager] Application resumed. Auto-reconnect disabled by user.");
+        }
+    }
+
+    private void OnStartScanPressed()
+    {
+        BeginScan(manualScanDurationSeconds);
+    }
+
+    private void OnStopScanPressed()
+    {
+        StopActiveScan();
+    }
+
+    private void BeginScan(float durationSeconds)
+    {
+        if (BLEPlugin.Instance == null)
+            return;
+
+        if (durationSeconds <= 0f)
+            durationSeconds = manualScanDurationSeconds;
+
+        StopActiveScan();
+
+        durationSeconds = Mathf.Max(0.5f, durationSeconds);
+        Debug.Log($"[BLEManager] Starting scan for {durationSeconds:F1}s.");
+        scanRoutine = StartCoroutine(ScanRoutine(durationSeconds));
+
+        if (autoReconnectEnabled)
+        {
+            if (trustedDiscoveryRoutine != null)
+            {
+                StopCoroutine(trustedDiscoveryRoutine);
+            }
+
+            trustedDiscoveryRoutine = StartCoroutine(TrustedDiscoveryWatch(AutoReconnectTimeoutSeconds));
+        }
+    }
+
+    private IEnumerator ScanRoutine(float durationSeconds)
+    {
+        BLEPlugin.Instance.StartScan();
+        SetScanState(true, durationSeconds);
+
+        float remaining = durationSeconds;
+        while (remaining > 0f)
+        {
+            yield return null;
+            remaining -= Time.deltaTime;
+            ScanStateChanged?.Invoke(true, Mathf.Max(0f, remaining));
+        }
+
+        scanRoutine = null;
+        StopActiveScan();
+    }
+
+    private void StopActiveScan()
+    {
+        if (scanRoutine != null)
+        {
+            StopCoroutine(scanRoutine);
+            scanRoutine = null;
+        }
+
+        if (!isScanning)
+        {
+            SetScanState(false, 0f);
+            return;
+        }
+
+        BLEPlugin.Instance?.StopScan();
+        Debug.Log("[BLEManager] Scan stopped.");
+        SetScanState(false, 0f);
+    }
+
+    private void SetScanState(bool scanning, float remainingSeconds)
+    {
+        isScanning = scanning;
+        if (startScan != null)
+            startScan.interactable = !scanning;
+        if (stopScan != null)
+            stopScan.interactable = scanning;
+
+        ScanStateChanged?.Invoke(scanning, Mathf.Max(0f, remainingSeconds));
     }
 
     // ----------------------------------------------------------------------
@@ -92,6 +238,11 @@ public class BLEManager : MonoBehaviour
         switch (ev.eventType)
         {
             case "scanResult":
+                if (devices.TryGetValue(ev.id, out var scanDevice))
+                {
+                    BLETrustedDeviceStore.MarkSeen(scanDevice);
+                    TryQueueAutoConnect(scanDevice);
+                }
                 break;
 
             case "ready":
@@ -105,7 +256,12 @@ public class BLEManager : MonoBehaviour
                 if (devices.TryGetValue(ev.id, out var connectedDevice))
                 {
                     connectedDevice.isConnected = true;
+                    pendingAutoConnections.Remove(connectedDevice.id);
+                    ClearAutoReconnectWatch(connectedDevice.id);
+                    BLETrustedDeviceStore.Remember(connectedDevice);
+                    UpdateMeasurementState(connectedDevice, MeasurementState.Idle);
                     NotifyConnected(connectedDevice); // ✅ notify listeners
+                    userRequestedDisconnects.Remove(connectedDevice.id);
                 }
                 break;
 
@@ -113,7 +269,21 @@ public class BLEManager : MonoBehaviour
                 if (devices.TryGetValue(ev.id, out var disconnectedDevice))
                 {
                     disconnectedDevice.isConnected = false;
+                    UpdateMeasurementState(disconnectedDevice, MeasurementState.Idle);
                     NotifyDisconnected(disconnectedDevice); // ✅ notify listeners
+
+                    pendingAutoConnections.Remove(disconnectedDevice.id);
+                    ClearAutoReconnectWatch(disconnectedDevice.id);
+
+                    if (autoReconnectEnabled && !userRequestedDisconnects.Contains(disconnectedDevice.id))
+                    {
+                        Debug.Log($"[BLEManager] Lost {disconnectedDevice.name}. Queuing recovery scan.");
+                        BeginScan(resumeScanDurationSeconds);
+                    }
+                    else
+                    {
+                        userRequestedDisconnects.Remove(disconnectedDevice.id);
+                    }
                 }
                 break;
 
@@ -143,6 +313,8 @@ public class BLEManager : MonoBehaviour
             return;
         }
 
+        UpdateMeasurementState(device, MeasurementState.Sampling);
+
         // Notify listeners
         NotifyData(device, raw);
 
@@ -158,6 +330,19 @@ public class BLEManager : MonoBehaviour
     }
 
 
+    private void UpdateMeasurementState(BleDevice device, MeasurementState state)
+    {
+        if (device == null)
+            return;
+
+        if (device.measurementState == state)
+            return;
+
+        device.measurementState = state;
+        NotifyMeasurementStateChanged(device, state);
+    }
+
+
 
 
 
@@ -169,6 +354,7 @@ public class BLEManager : MonoBehaviour
 
         if (profile.AutoStartMeasurement)
         {
+            UpdateMeasurementState(device, MeasurementState.Starting);
             StartCoroutine(AutoStartAfterDelay(device.id, profile));
         }
     }
@@ -182,6 +368,149 @@ public class BLEManager : MonoBehaviour
         if (BLEPlugin.Instance != null && profile.StartCommand != null)
         {
             BLEPlugin.Instance.SendControl(deviceId, profile.StartCommand, "start");
+            if (devices.TryGetValue(deviceId, out var device))
+            {
+                UpdateMeasurementState(device, MeasurementState.Sampling);
+            }
+        }
+        else if (devices.TryGetValue(deviceId, out var fallbackDevice))
+        {
+            UpdateMeasurementState(fallbackDevice, MeasurementState.Idle);
+        }
+    }
+
+
+
+    private void TryQueueAutoConnect(BleDevice device)
+    {
+        if (!autoReconnectEnabled || BLEPlugin.Instance == null)
+            return;
+
+        if (device == null || device.isConnected || device.type == DeviceType.Unknown)
+            return;
+
+        if (string.IsNullOrEmpty(device.id))
+            return;
+
+        if (!BLETrustedDeviceStore.Contains(device.id))
+            return;
+
+        if (pendingAutoConnections.Contains(device.id) || userRequestedDisconnects.Contains(device.id))
+            return;
+
+        var profile = BleDeviceProfiles.TryGetProfile(device.type);
+        if (profile == null)
+            return;
+
+        BLETrustedDeviceStore.RememberProfileHint(device.id, profile, device.name);
+        pendingAutoConnections.Add(device.id);
+        Debug.Log($"[BLEManager] Auto-connecting to trusted device {device.name} ({device.id})");
+        BLEPlugin.Instance.Connect(device.id, profile);
+        StartAutoReconnectTimeout(device.id);
+    }
+
+    private void StartAutoReconnectTimeout(string deviceId)
+    {
+        if (string.IsNullOrEmpty(deviceId))
+            return;
+
+        if (autoReconnectTimeouts.TryGetValue(deviceId, out var existing))
+        {
+            StopCoroutine(existing);
+            autoReconnectTimeouts.Remove(deviceId);
+        }
+
+        var routine = StartCoroutine(AutoReconnectTimeout(deviceId, AutoReconnectTimeoutSeconds));
+        autoReconnectTimeouts[deviceId] = routine;
+    }
+
+    private IEnumerator AutoReconnectTimeout(string deviceId, float timeoutSeconds)
+    {
+        float elapsed = 0f;
+        while (elapsed < timeoutSeconds)
+        {
+            if (!pendingAutoConnections.Contains(deviceId))
+            {
+                break;
+            }
+
+            if (devices.TryGetValue(deviceId, out var device) && device.isConnected)
+            {
+                autoReconnectTimeouts.Remove(deviceId);
+                yield break;
+            }
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        autoReconnectTimeouts.Remove(deviceId);
+
+        if (devices.TryGetValue(deviceId, out var failedDevice) && pendingAutoConnections.Remove(deviceId))
+        {
+            Debug.LogWarning($"[BLEManager] Auto-connection to {failedDevice.name} timed out.");
+            ShowToast($"Couldn't auto-connect to {failedDevice.name}. Tap connect to retry.");
+        }
+        else if (pendingAutoConnections.Remove(deviceId))
+        {
+            Debug.LogWarning($"[BLEManager] Auto-connection to {deviceId} timed out.");
+            if (BLETrustedDeviceStore.TryGet(deviceId, out var record) && !string.IsNullOrEmpty(record.Name))
+            {
+                ShowToast($"Couldn't auto-connect to {record.Name}. Tap connect to retry.");
+            }
+            else
+            {
+                ShowToast("Couldn't auto-connect. Try connecting manually.");
+            }
+        }
+    }
+
+    private void ClearAutoReconnectWatch(string deviceId)
+    {
+        if (string.IsNullOrEmpty(deviceId))
+            return;
+
+        if (autoReconnectTimeouts.TryGetValue(deviceId, out var routine))
+        {
+            StopCoroutine(routine);
+            autoReconnectTimeouts.Remove(deviceId);
+        }
+    }
+
+    private IEnumerator TrustedDiscoveryWatch(float timeoutSeconds)
+    {
+        yield return new WaitForSeconds(timeoutSeconds);
+        trustedDiscoveryRoutine = null;
+
+        if (!autoReconnectEnabled)
+            yield break;
+
+        var missingDevices = new List<string>();
+        foreach (var record in BLETrustedDeviceStore.TrustedDevices)
+        {
+            if (record == null || string.IsNullOrEmpty(record.DeviceId))
+                continue;
+
+            if (userRequestedDisconnects.Contains(record.DeviceId))
+                continue;
+
+            if (devices.TryGetValue(record.DeviceId, out var device) && device.isConnected)
+                continue;
+
+            if (pendingAutoConnections.Contains(record.DeviceId))
+                continue;
+
+            var label = !string.IsNullOrEmpty(record.Name) ? record.Name : record.DeviceId;
+            missingDevices.Add(label);
+        }
+
+        if (missingDevices.Count > 0)
+        {
+            string joined = missingDevices.Count == 1
+                ? missingDevices[0]
+                : string.Join(", ", missingDevices);
+
+            ShowToast($"Couldn't find {joined}. Tap Start Scan to retry.");
         }
     }
 
@@ -246,11 +575,23 @@ public class BLEManager : MonoBehaviour
         }
     }
 
+    private void NotifyMeasurementStateChanged(BleDevice device, MeasurementState state)
+    {
+        MeasurementStateChanged?.Invoke(device, state);
+
+        if (listeners.TryGetValue(device.id, out var list))
+        {
+            foreach (var l in list)
+                l.OnMeasurementStateChanged(device, state);
+        }
+    }
+
     // ----------------------------------------------------------------------
     // --- PUBLIC BLE ACTIONS ----------------------------------------------
     // ----------------------------------------------------------------------
     public void Connect(string deviceId, DeviceType type)
     {
+        userRequestedDisconnects.Remove(deviceId);
         var profile = BleDeviceProfiles.TryGetProfile(type);
         if (profile == null)
         {
@@ -258,14 +599,31 @@ public class BLEManager : MonoBehaviour
             return;
         }
 
+        if (devices.TryGetValue(deviceId, out var device))
+        {
+            device.type = type;
+            BLETrustedDeviceStore.RememberProfileHint(deviceId, profile, device.name);
+        }
+        else
+        {
+            BLETrustedDeviceStore.RememberProfileHint(deviceId, profile);
+        }
+
         BLEPlugin.Instance.Connect(deviceId, profile);
     }
 
-    public void DisConnect(string deviceId) =>
+    public void DisConnect(string deviceId)
+    {
+        if (!string.IsNullOrEmpty(deviceId))
+        {
+            userRequestedDisconnects.Add(deviceId);
+        }
+
         BLEPlugin.Instance.Disconnect(deviceId);
+    }
 
     public void StopScan() =>
-        BLEPlugin.Instance.StopScan();
+        StopActiveScan();
 
     public void StartMeasurement(string deviceId)
     {
@@ -273,10 +631,14 @@ public class BLEManager : MonoBehaviour
             return;
 
         var profile = BleDeviceProfiles.TryGetProfile(device.type);
+        UpdateMeasurementState(device, MeasurementState.Starting);
+
         if (profile?.StartCommand != null)
         {
             BLEPlugin.Instance.SendControl(deviceId, profile.StartCommand, "start");
         }
+
+        UpdateMeasurementState(device, MeasurementState.Sampling);
     }
 
     public void StopMeasurement(string deviceId)
@@ -289,6 +651,8 @@ public class BLEManager : MonoBehaviour
         {
             BLEPlugin.Instance.SendControl(deviceId, profile.StopCommand, "stop");
         }
+
+        UpdateMeasurementState(device, MeasurementState.Idle);
     }
 
     public void PauseMeasurement(string deviceId)
@@ -301,5 +665,41 @@ public class BLEManager : MonoBehaviour
         {
             BLEPlugin.Instance.SendControl(deviceId, profile.PauseCommand, "pause");
         }
+        UpdateMeasurementState(device, MeasurementState.Paused);
+    }
+
+    public void SetAutoReconnectEnabled(bool enabled)
+    {
+        if (autoReconnectEnabled == enabled)
+            return;
+
+        autoReconnectEnabled = enabled;
+        Debug.Log($"[BLEManager] Auto-reconnect {(enabled ? "enabled" : "disabled")}.");
+        PlayerPrefs.SetInt(AutoReconnectPrefsKey, enabled ? 1 : 0);
+        PlayerPrefs.Save();
+
+        if (!autoReconnectEnabled)
+        {
+            foreach (var deviceId in new List<string>(pendingAutoConnections))
+            {
+                ClearAutoReconnectWatch(deviceId);
+            }
+
+            pendingAutoConnections.Clear();
+
+            if (trustedDiscoveryRoutine != null)
+            {
+                StopCoroutine(trustedDiscoveryRoutine);
+                trustedDiscoveryRoutine = null;
+            }
+        }
+    }
+
+    private void ShowToast(string message)
+    {
+        if (toast == null || string.IsNullOrEmpty(message))
+            return;
+
+        toast.Show(message);
     }
 }

--- a/BLEUnity/Assets/Scripts/BLETrustedDeviceStore.cs
+++ b/BLEUnity/Assets/Scripts/BLETrustedDeviceStore.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using UnityEngine;
+
+/// <summary>
+/// Persists trusted BLE devices so we can automatically reconnect to them on future runs.
+/// Backed by PlayerPrefs so it works across platforms without additional plugins.
+/// </summary>
+public static class BLETrustedDeviceStore
+{
+    private const string PlayerPrefsKey = "ble.trustedDevices";
+
+    private static readonly Dictionary<string, TrustedDeviceRecord> records;
+
+    static BLETrustedDeviceStore()
+    {
+        records = LoadRecords();
+    }
+
+    public static IReadOnlyCollection<TrustedDeviceRecord> TrustedDevices => records.Values;
+
+    public static bool Contains(string deviceId)
+    {
+        return !string.IsNullOrEmpty(deviceId) && records.ContainsKey(deviceId);
+    }
+
+    /// <summary>
+    /// Saves/updates a trusted device entry. Called whenever the user successfully connects.
+    /// </summary>
+    public static void Remember(BleDevice device)
+    {
+        if (device == null || string.IsNullOrEmpty(device.id))
+            return;
+
+        if (!records.TryGetValue(device.id, out var record))
+        {
+            record = new TrustedDeviceRecord(device.id);
+            records[device.id] = record;
+        }
+
+        record.Update(device);
+        SaveRecords();
+    }
+
+    /// <summary>
+    /// Persists a profile hint for a device before the first successful connection completes.
+    /// </summary>
+    public static void RememberProfileHint(string deviceId, BleDeviceProfileDefinition profile, string displayName = null)
+    {
+        if (string.IsNullOrEmpty(deviceId) || profile == null)
+            return;
+
+        if (!records.TryGetValue(deviceId, out var record))
+        {
+            record = new TrustedDeviceRecord(deviceId);
+            records[deviceId] = record;
+        }
+
+        record.SetProfile(profile, displayName);
+        SaveRecords();
+    }
+
+    /// <summary>
+    /// Updates the "last seen" timestamp for a trusted device while scanning.
+    /// </summary>
+    public static void MarkSeen(BleDevice device)
+    {
+        if (device == null || string.IsNullOrEmpty(device.id))
+            return;
+
+        if (!records.TryGetValue(device.id, out var record))
+            return;
+
+        record.Update(device, updateTrustedState: false);
+        SaveRecords();
+    }
+
+    public static bool TryGet(string deviceId, out TrustedDeviceRecord record)
+    {
+        if (string.IsNullOrEmpty(deviceId))
+        {
+            record = null;
+            return false;
+        }
+
+        return records.TryGetValue(deviceId, out record);
+    }
+
+    public static void Forget(string deviceId)
+    {
+        if (string.IsNullOrEmpty(deviceId))
+            return;
+
+        if (records.Remove(deviceId))
+        {
+            SaveRecords();
+        }
+    }
+
+    private static Dictionary<string, TrustedDeviceRecord> LoadRecords()
+    {
+        if (!PlayerPrefs.HasKey(PlayerPrefsKey))
+            return new Dictionary<string, TrustedDeviceRecord>();
+
+        try
+        {
+            var json = PlayerPrefs.GetString(PlayerPrefsKey);
+            if (string.IsNullOrEmpty(json))
+                return new Dictionary<string, TrustedDeviceRecord>();
+
+            var list = JsonConvert.DeserializeObject<List<TrustedDeviceRecord>>(json);
+            var dict = new Dictionary<string, TrustedDeviceRecord>();
+            if (list != null)
+            {
+                foreach (var record in list)
+                {
+                    if (record != null && !string.IsNullOrEmpty(record.DeviceId))
+                    {
+                        dict[record.DeviceId] = record;
+                    }
+                }
+            }
+
+            return dict;
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[BLETrustedDeviceStore] Failed to load trusted devices: {ex}");
+            return new Dictionary<string, TrustedDeviceRecord>();
+        }
+    }
+
+    private static void SaveRecords()
+    {
+        try
+        {
+            var json = JsonConvert.SerializeObject(records.Values, Formatting.None);
+            PlayerPrefs.SetString(PlayerPrefsKey, json);
+            PlayerPrefs.Save();
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[BLETrustedDeviceStore] Failed to save trusted devices: {ex}");
+        }
+    }
+
+    [Serializable]
+    public sealed class TrustedDeviceRecord
+    {
+        [JsonProperty("deviceId")] private string deviceId;
+        [JsonProperty("name")] private string name;
+        [JsonProperty("type")] private DeviceType type;
+        [JsonProperty("lastSeenUnixSeconds")] private long lastSeenUnixSeconds;
+        [JsonProperty("profileKey")] private string profileKey;
+
+        [JsonConstructor]
+        public TrustedDeviceRecord(string deviceId)
+        {
+            this.deviceId = deviceId;
+        }
+
+        public string DeviceId => deviceId;
+        public string Name => name;
+        public DeviceType Type => type;
+        public string ProfileKey => profileKey;
+        public DateTimeOffset LastSeenUtc =>
+            lastSeenUnixSeconds > 0
+                ? DateTimeOffset.FromUnixTimeSeconds(lastSeenUnixSeconds)
+                : DateTimeOffset.MinValue;
+
+        internal void Update(BleDevice device, bool updateTrustedState = true)
+        {
+            if (device == null)
+                return;
+
+            if (!string.IsNullOrEmpty(device.name))
+                name = device.name;
+
+            if (updateTrustedState)
+            {
+                type = device.type;
+                profileKey = device.type.ToString();
+            }
+
+            lastSeenUnixSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        }
+
+        internal void SetProfile(BleDeviceProfileDefinition profile, string displayName)
+        {
+            if (profile == null)
+                return;
+
+            profileKey = profile.Type.ToString();
+
+            if (!string.IsNullOrEmpty(displayName))
+            {
+                name = displayName;
+            }
+        }
+    }
+}

--- a/BLEUnity/Assets/Scripts/BLETrustedDeviceStore.cs.meta
+++ b/BLEUnity/Assets/Scripts/BLETrustedDeviceStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c5a0b0d2e9a4f02a9c6ad86e0d6a60a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BLEUnity/Assets/Scripts/Interface/IBLEDeviceListener.cs
+++ b/BLEUnity/Assets/Scripts/Interface/IBLEDeviceListener.cs
@@ -11,4 +11,7 @@ public interface IBLEDeviceListener
 
     /// <summary>Called when new data arrives from the device.</summary>
     void OnData(BleDevice device, byte[] rawData);
+
+    /// <summary>Called whenever a measurement state transition occurs.</summary>
+    void OnMeasurementStateChanged(BleDevice device, MeasurementState state);
 }

--- a/BLEUnity/Assets/Scripts/Models/BLEDevice.cs
+++ b/BLEUnity/Assets/Scripts/Models/BLEDevice.cs
@@ -8,6 +8,14 @@ public enum DeviceType
     BioPot = 2,
 }
 
+public enum MeasurementState
+{
+    Idle = 0,
+    Starting = 1,
+    Sampling = 2,
+    Paused = 3
+}
+
 
 
 [System.Serializable]
@@ -30,6 +38,7 @@ public class BleDevice
     public DeviceType type;
     public bool isConnected;
     public int rssi;
+    public MeasurementState measurementState = MeasurementState.Idle;
 }
 
 

--- a/BLEUnity/Assets/Scripts/UI_BLEDeviceItem.cs
+++ b/BLEUnity/Assets/Scripts/UI_BLEDeviceItem.cs
@@ -14,12 +14,25 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
     [SerializeField] private Button connectButton;
     [SerializeField] private Button disconnectButton;
 
+    [Header("Measurement Controls")]
+    [SerializeField] private Button startMeasurementButton;
+    [SerializeField] private Button pauseMeasurementButton;
+    [SerializeField] private Button stopMeasurementButton;
+    [SerializeField] private TMP_Text measurementStatusText;
+
     [Header("Data Output")]
     [SerializeField] private TMP_Text line1Text; // For main parsed data (EEG/Quaternion)
     [SerializeField] private TMP_Text line2Text; // For secondary data (Accel, etc.)
     [SerializeField] private TMP_Text line3Text; // For debug or misc info
 
     private BleDevice device;
+    private MeasurementState currentMeasurementState = MeasurementState.Idle;
+
+    private string lastLine1;
+    private string lastLine2;
+    private string lastLine3;
+    private bool hasData;
+    private bool dataStale;
 
     // Device-specific parsers
     private MovellaSignalParser movellaParser;
@@ -45,6 +58,10 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
     public void Setup(BleDevice dev)
     {
         device = dev;
+
+        lastLine1 = lastLine2 = lastLine3 = string.Empty;
+        hasData = false;
+        dataStale = false;
 
         nameText.text = dev.name ?? "(Unnamed)";
         UpdateStatus(dev);
@@ -74,10 +91,44 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
             BLEManager.Instance.DisConnect(dev.id);
         });
 
+        if (startMeasurementButton != null)
+        {
+            startMeasurementButton.onClick.RemoveAllListeners();
+            startMeasurementButton.onClick.AddListener(() =>
+            {
+                if (BLEManager.Instance != null)
+                    BLEManager.Instance.StartMeasurement(dev.id);
+            });
+        }
+
+        if (pauseMeasurementButton != null)
+        {
+            pauseMeasurementButton.onClick.RemoveAllListeners();
+            pauseMeasurementButton.onClick.AddListener(() =>
+            {
+                if (BLEManager.Instance != null)
+                    BLEManager.Instance.PauseMeasurement(dev.id);
+            });
+        }
+
+        if (stopMeasurementButton != null)
+        {
+            stopMeasurementButton.onClick.RemoveAllListeners();
+            stopMeasurementButton.onClick.AddListener(() =>
+            {
+                if (BLEManager.Instance != null)
+                    BLEManager.Instance.StopMeasurement(dev.id);
+            });
+        }
+
         bool hasProfile = BleDeviceProfiles.TryGetProfile(dev.type) != null;
         connectButton.interactable = hasProfile;
 
         BLEManager.Instance.AddListener(dev.id, this);
+
+        currentMeasurementState = dev.measurementState;
+        UpdateMeasurementUI(currentMeasurementState);
+        RefreshDataLabels();
     }
 
     /// <summary>
@@ -95,13 +146,104 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
         connectButton.gameObject.SetActive(!connected);
         disconnectButton.gameObject.SetActive(connected);
 
-        // Clear data when disconnected
-        if (!connected)
+        UpdateMeasurementUI(dev.measurementState);
+    }
+
+    private void UpdateMeasurementUI(MeasurementState state)
+    {
+        currentMeasurementState = state;
+        bool connected = device != null && device.isConnected;
+
+        if (measurementStatusText != null)
         {
-            line1Text.text = "";
-            line2Text.text = "";
-            line3Text.text = "";
+            if (!connected)
+            {
+                measurementStatusText.text = "<color=#888888>Disconnected</color>";
+            }
+            else
+            {
+                switch (state)
+                {
+                    case MeasurementState.Sampling:
+                        measurementStatusText.text = "<color=green>Sampling…</color>";
+                        break;
+                    case MeasurementState.Paused:
+                        measurementStatusText.text = "<color=#ffcc00>Paused</color>";
+                        break;
+                    case MeasurementState.Starting:
+                        measurementStatusText.text = "Starting…";
+                        break;
+                    default:
+                        measurementStatusText.text = "<color=#888888>Stopped</color>";
+                        break;
+                }
+            }
         }
+
+        if (startMeasurementButton != null)
+            startMeasurementButton.interactable = connected && (state == MeasurementState.Idle || state == MeasurementState.Paused);
+        if (pauseMeasurementButton != null)
+            pauseMeasurementButton.interactable = connected && state == MeasurementState.Sampling;
+        if (stopMeasurementButton != null)
+            stopMeasurementButton.interactable = connected && (state == MeasurementState.Sampling || state == MeasurementState.Paused || state == MeasurementState.Starting);
+
+        bool shouldMarkStale = !connected || state != MeasurementState.Sampling;
+        dataStale = shouldMarkStale && hasData;
+
+        if (!hasData && connected && state == MeasurementState.Sampling)
+        {
+            dataStale = true;
+        }
+
+        RefreshDataLabels();
+    }
+
+    private void RefreshDataLabels()
+    {
+        bool connected = device != null && device.isConnected;
+
+        if (!hasData)
+        {
+            if (line1Text != null)
+            {
+                if (connected)
+                {
+                    line1Text.text = dataStale
+                        ? "<color=#888888>Waiting for data…</color>"
+                        : "Waiting for data…";
+                }
+                else
+                {
+                    line1Text.text = string.Empty;
+                }
+            }
+
+            if (line2Text != null)
+                line2Text.text = string.Empty;
+            if (line3Text != null)
+                line3Text.text = string.Empty;
+            return;
+        }
+
+        SetDataText(line1Text, lastLine1);
+        SetDataText(line2Text, lastLine2);
+        SetDataText(line3Text, lastLine3);
+    }
+
+    private void SetDataText(TMP_Text label, string value)
+    {
+        if (label == null)
+            return;
+
+        if (string.IsNullOrEmpty(value))
+        {
+            label.text = string.Empty;
+            return;
+        }
+
+        label.text = dataStale
+            ? $"{value} <color=#888888><i>(last)</i></color>"
+            : value;
     }
 
     #region IBLEDeviceListener Implementation
@@ -110,9 +252,6 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
     {
         Debug.Log($"[UI_BLEDeviceItem] {dev.name} connected");
         UpdateStatus(dev);
-        line1Text.text = "Waiting for data...";
-        line2Text.text = "";
-        line3Text.text = "";
     }
 
     public void OnDisconnected(BleDevice dev)
@@ -126,15 +265,18 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
         if (rawData == null || rawData.Length == 0)
             return;
 
+        bool updated = false;
+
         switch (dev.type)
         {
             case DeviceType.Movella:
                 if (movellaParser != null && movellaParser.TryParse(rawData))
                 {
                     // Display parsed Movella sensor data
-                    line1Text.text = $"<b>Quat:</b> {string.Join(", ", movellaParser.Quaternion)}";
-                    line2Text.text = $"<b>Accel:</b> {string.Join(", ", movellaParser.FreeAcceleration)}";
-                    line3Text.text = $"<b>Status:</b> {movellaParser.Status} | ClipA:{movellaParser.ClippingCountAccelerometer} ClipG:{movellaParser.ClippingCountGyroscope}";
+                    lastLine1 = $"<b>Quat:</b> {string.Join(", ", movellaParser.Quaternion)}";
+                    lastLine2 = $"<b>Accel:</b> {string.Join(", ", movellaParser.FreeAcceleration)}";
+                    lastLine3 = $"<b>Status:</b> {movellaParser.Status} | ClipA:{movellaParser.ClippingCountAccelerometer} ClipG:{movellaParser.ClippingCountGyroscope}";
+                    updated = true;
                 }
                 break;
 
@@ -150,7 +292,8 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
                         string eegValues = "";
                         for (int s = 0; s < Mathf.Min(eeg.GetLength(1), 5); s++)
                             eegValues += eeg[0, s].ToString("F2") + ", ";
-                        line1Text.text = $"<b>EEG (Ch0):</b> {eegValues}";
+                        lastLine1 = $"<b>EEG (Ch0):</b> {eegValues}";
+                        updated = true;
                     }
 
                     if (acc != null && acc.Length > 0)
@@ -158,7 +301,8 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
                         string accValues = "";
                         for (int i = 0; i < Mathf.Min(acc.Length, 3); i++)
                             accValues += acc[i].ToString("F2") + ", ";
-                        line2Text.text = $"<b>Accel:</b> {accValues}";
+                        lastLine2 = $"<b>Accel:</b> {accValues}";
+                        updated = true;
                     }
 
                     if (bio != null && bio.Length > 0)
@@ -166,11 +310,27 @@ public class UI_BLEDeviceItem : MonoBehaviour, IBLEDeviceListener
                         string bioValues = "";
                         for (int i = 0; i < Mathf.Min(bio.Length, 3); i++)
                             bioValues += bio[i].ToString("F2") + ", ";
-                        line3Text.text = $"<b>Bio:</b> {bioValues}";
+                        lastLine3 = $"<b>Bio:</b> {bioValues}";
+                        updated = true;
                     }
                 }
                 break;
         }
+
+        if (updated)
+        {
+            hasData = true;
+            dataStale = false;
+            UpdateMeasurementUI(currentMeasurementState);
+        }
+    }
+
+    public void OnMeasurementStateChanged(BleDevice dev, MeasurementState state)
+    {
+        if (device == null || dev.id != device.id)
+            return;
+
+        UpdateMeasurementUI(state);
     }
 
     #endregion

--- a/BLEUnity/Assets/Scripts/UI_BLEScanStatus.cs
+++ b/BLEUnity/Assets/Scripts/UI_BLEScanStatus.cs
@@ -1,0 +1,47 @@
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// Displays the current scan state (Idle/Scanning) and optional countdown.
+/// Attach to a banner or status widget in the UI.
+/// </summary>
+public class UI_BLEScanStatus : MonoBehaviour
+{
+    [SerializeField] private TMP_Text statusLabel;
+    [SerializeField] private GameObject scanningIndicator;
+    [SerializeField] private GameObject idleIndicator;
+
+    private void OnEnable()
+    {
+        if (BLEManager.Instance != null)
+        {
+            BLEManager.Instance.ScanStateChanged += HandleScanStateChanged;
+            HandleScanStateChanged(BLEManager.Instance.IsScanning, 0f);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (BLEManager.Instance != null)
+        {
+            BLEManager.Instance.ScanStateChanged -= HandleScanStateChanged;
+        }
+    }
+
+    private void HandleScanStateChanged(bool scanning, float remainingSeconds)
+    {
+        if (statusLabel != null)
+        {
+            statusLabel.text = scanning
+                ? (remainingSeconds > 0f
+                    ? $"Scanning… ({Mathf.CeilToInt(remainingSeconds)}s)"
+                    : "Scanning…")
+                : "Idle";
+        }
+
+        if (scanningIndicator != null)
+            scanningIndicator.SetActive(scanning);
+        if (idleIndicator != null)
+            idleIndicator.SetActive(!scanning);
+    }
+}

--- a/BLEUnity/Assets/Scripts/UI_BLEScanStatus.cs.meta
+++ b/BLEUnity/Assets/Scripts/UI_BLEScanStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a5c5d957f9a4e06a61e7d820ee7da17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BLEUnity/Assets/Scripts/UI_BLEToast.cs
+++ b/BLEUnity/Assets/Scripts/UI_BLEToast.cs
@@ -1,0 +1,98 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// Lightweight toast/bubble notification for BLE workflow feedback.
+/// </summary>
+public class UI_BLEToast : MonoBehaviour
+{
+    public static UI_BLEToast Instance { get; private set; }
+
+    [SerializeField] private TMP_Text messageLabel;
+    [SerializeField] private CanvasGroup canvasGroup;
+    [SerializeField, Min(0.1f)] private float displaySeconds = 3f;
+    [SerializeField, Min(0.05f)] private float fadeDuration = 0.2f;
+
+    private Coroutine routine;
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else if (Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        if (canvasGroup != null)
+        {
+            canvasGroup.alpha = 0f;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    /// <summary>
+    /// Displays a toast message for the configured duration.
+    /// </summary>
+    public void Show(string message, float? durationOverride = null)
+    {
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        if (routine != null)
+        {
+            StopCoroutine(routine);
+        }
+
+        float duration = durationOverride.HasValue && durationOverride.Value > 0f
+            ? durationOverride.Value
+            : displaySeconds;
+
+        routine = StartCoroutine(ShowRoutine(message, duration));
+    }
+
+    private IEnumerator ShowRoutine(string message, float duration)
+    {
+        if (messageLabel != null)
+        {
+            messageLabel.text = message;
+        }
+
+        yield return FadeTo(1f);
+        yield return new WaitForSeconds(duration);
+        yield return FadeTo(0f);
+
+        routine = null;
+    }
+
+    private IEnumerator FadeTo(float targetAlpha)
+    {
+        if (canvasGroup == null)
+        {
+            yield break;
+        }
+
+        float startAlpha = canvasGroup.alpha;
+        float elapsed = 0f;
+        while (elapsed < fadeDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = fadeDuration > 0f ? Mathf.Clamp01(elapsed / fadeDuration) : 1f;
+            canvasGroup.alpha = Mathf.Lerp(startAlpha, targetAlpha, t);
+            yield return null;
+        }
+
+        canvasGroup.alpha = targetAlpha;
+    }
+}

--- a/BLEUnity/Assets/Scripts/UI_BLEToast.cs.meta
+++ b/BLEUnity/Assets/Scripts/UI_BLEToast.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cf6ba6ff0cc4a7aa98ae0a0dd9557be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/BLEUnity/Documentation/BLEWorkflow.md
+++ b/BLEUnity/Documentation/BLEWorkflow.md
@@ -1,0 +1,57 @@
+# Recommended BLE App Workflow
+
+This document outlines a suggested end-to-end workflow for the Unity BLE sample, including scanning, pairing, reconnection, and UI/UX considerations.
+
+## 1. App launch & permissions
+1. Display a lightweight loading state while requesting permissions.
+2. Request Bluetooth, location, and notification permissions on launch. Defer heavy UI interactions until `BLEPlugin.PermissionGranted` is `true` to avoid confusing failures.
+3. If permissions are denied, surface a modal with retry instructions and a deep link to system settings.
+
+_Implementation hook_: `BLEManager.Start()` already waits for `BLEPlugin.Instance.PermissionGranted` before calling `Init()`. 【F:BLEUnity/Assets/Scripts/BLEManager.cs†L56-L75】
+
+## 2. Scanning flow
+1. Auto-start a **short discovery scan** after initialization (5–10 seconds) to populate known devices without requiring the user to press "Start Scan".
+2. Keep manual scan controls accessible for troubleshooting or when a user wants to find a brand-new sensor.
+3. Display scan state in the UI (e.g., progress indicator or "Scanning…" label) and disable duplicate scans while one is in flight.
+
+_Implementation details_: `BLEManager` orchestrates the automatic launch scan, manual scan throttling, and countdown updates via `BeginScan`, `ScanRoutine`, and the `ScanStateChanged` event, while `UI_BLEScanStatus` surfaces the state in the HUD. 【F:BLEUnity/Assets/Scripts/BLEManager.cs†L56-L165】【F:BLEUnity/Assets/Scripts/UI_BLEScanStatus.cs†L1-L38】
+
+## 3. Device discovery list
+1. Show all discovered devices with connection status, RSSI, and device-type-specific iconography.
+2. Collapse unknown/unsupported peripherals into a secondary list to reduce clutter. The existing `UI_BLEDeviceList.Refresh()` already removes entries whose profile is unknown—keep that behavior but provide an informational banner so users understand why devices disappear. 【F:BLEUnity/Assets/Scripts/UI_BLEDeviceList.cs†L17-L45】
+3. Surface a "Last seen" timestamp and sort by signal strength to help users pick the right device quickly.
+
+## 4. Connection & pairing
+1. When the user taps **Connect** for the first time, persist the device ID and profile in local storage (e.g., `PlayerPrefs` or a lightweight JSON file).
+2. On subsequent app launches, automatically reconnect to previously trusted devices as soon as they are discovered. Allow users to opt out from settings.
+3. If auto-connection fails (e.g., device not found within 15 seconds), show a non-blocking toast and prompt the user to retry manually.
+4. Keep connect/disconnect controls visible per device. `UI_BLEDeviceItem` already toggles button state based on connection status—retain this responsive feedback. 【F:BLEUnity/Assets/Scripts/UI_BLEDeviceItem.cs†L43-L107】
+
+_Implementation details_: Trusted devices are cached with `BLETrustedDeviceStore`, and `BLEManager.TryQueueAutoConnect` reconnects to them after each scan result while respecting manual disconnects. 【F:BLEUnity/Assets/Scripts/BLETrustedDeviceStore.cs†L1-L109】【F:BLEUnity/Assets/Scripts/BLEManager.cs†L207-L350】【F:BLEUnity/Assets/Scripts/BLEManager.cs†L415-L440】
+
+## 5. Measurement lifecycle
+1. Once a device reports `ready`, kick off measurement automatically when the profile requires it. This already exists via `BleDeviceProfiles` and `AutoStartAfterDelay`; ensure profile metadata stays accurate. 【F:BLEUnity/Assets/Scripts/BLEManager.cs†L299-L321】【F:BLEUnity/Assets/Scripts/Profiles/BleDeviceProfiles.cs†L5-L42】
+2. Provide explicit **Start**, **Pause**, and **Stop** controls for advanced users. Surface the command feedback (e.g., "Sampling…", "Paused") near the data readout.
+3. When disconnecting, clear data panels but persist the last values until a new reading arrives to avoid flicker.
+
+## 6. Background resilience
+1. Handle app suspension by pausing measurements and releasing the scan to conserve battery.
+2. On resume, re-run a quick scan and reconnect to trusted devices.
+3. Log reconnection attempts so testers can diagnose hardware stability.
+
+_Implementation details_: `BLEManager.OnApplicationPause` pauses active measurements, stops scanning when the app is backgrounded, and relaunches a short recovery scan on resume. 【F:BLEUnity/Assets/Scripts/BLEManager.cs†L77-L105】
+
+## 7. Settings & maintenance
+1. Provide a settings screen with:
+   - Trusted devices list (with remove/forget action).
+   - Scan duration and auto-reconnect toggles.
+   - Debug logging level switch for support builds.
+2. Offer a "Report issue" shortcut that exports recent logs.
+
+## 8. UX polish checklist
+- Always show which state the BLE stack is in (Idle, Scanning, Connecting, Connected, Streaming).
+- Disable destructive actions (e.g., Stop Scan) while the underlying native call is outstanding.
+- Use toast or snackbar notifications for transient states and error handling.
+- Animate transitions (e.g., fade in data panels) to reassure users that the app is responsive.
+
+Following this workflow keeps the onboarding flow simple (automatic scan + reconnection), while preserving manual controls for power users and QA. It also leans on the existing code structure, so the implementation involves incremental updates rather than a full rewrite.


### PR DESCRIPTION
## Summary
- auto-run launch/resume scans, log transitions, and add auto reconnect timeout/toast handling in `BLEManager`
- persist trusted device profile metadata and expose measurement-state events for listeners
- add measurement control UI, stale data handling, and a toast presenter for manual start/pause/stop feedback

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e4c8ca574c83268812db5b4664153d