### PR TITLE
Respect manual disconnects when auto-reconnecting trusted BLE devices

### DIFF
--- a/BLEUnity/Assets/Scripts/BLEManager.cs
+++ b/BLEUnity/Assets/Scripts/BLEManager.cs
@@ -180,6 +180,7 @@ public class BLEManager : MonoBehaviour
                     connectedDevice.isReady = false;
                     SetMeasurementState(connectedDevice, MeasurementState.Idle);
                     NotifyConnected(connectedDevice); // ✅ notify listeners
+                    TrustedDeviceStore.SetLastConnectionState(connectedDevice.id, connectedDevice.type, true);
                 }
                 break;
 
@@ -244,7 +245,16 @@ public class BLEManager : MonoBehaviour
 
         if (device.isTrusted)
         {
-            TryBeginAutoConnect(device);
+            if (TrustedDeviceStore.ShouldAutoReconnect(device.id))
+            {
+                TryBeginAutoConnect(device);
+            }
+            else
+            {
+                device.isAutoConnecting = false;
+                device.autoConnectFailed = false;
+                device.connectionNote = string.Empty;
+            }
         }
     }
 
@@ -469,8 +479,15 @@ public class BLEManager : MonoBehaviour
             UI_BLEDeviceList.Instance.Refresh(devices.Values);
     }
 
-    public void DisConnect(string deviceId) =>
+    public void DisConnect(string deviceId)
+    {
+        if (devices.TryGetValue(deviceId, out var device))
+            TrustedDeviceStore.SetLastConnectionState(deviceId, device.type, false);
+        else
+            TrustedDeviceStore.SetLastConnectionState(deviceId, DeviceType.Unknown, false);
+
         BLEPlugin.Instance.Disconnect(deviceId);
+    }
 
     public void StopScan() =>
         BLEPlugin.Instance.StopScan();

--- a/BLEUnity/Assets/Scripts/TrustedDeviceStore.cs
+++ b/BLEUnity/Assets/Scripts/TrustedDeviceStore.cs
@@ -9,6 +9,7 @@ public class TrustedDeviceRecord
 {
     public string id;
     public DeviceType type;
+    public bool? lastConnected;
 }
 
 public static class TrustedDeviceStore
@@ -92,11 +93,58 @@ public static class TrustedDeviceStore
         var existing = cache.FirstOrDefault(r => r.id == id);
         if (existing == null)
         {
-            cache.Add(new TrustedDeviceRecord { id = id, type = type });
+            cache.Add(new TrustedDeviceRecord
+            {
+                id = id,
+                type = type,
+                lastConnected = null
+            });
         }
         else
         {
             existing.type = type;
+        }
+
+        Save();
+    }
+
+    public static bool ShouldAutoReconnect(string id)
+    {
+        if (TryGet(id, out var record))
+        {
+            // Default to auto-reconnect unless the last known state was an
+            // intentional disconnect (false). Null indicates legacy data or an
+            // unknown state, so we continue to auto-reconnect for backward
+            // compatibility.
+            return record.lastConnected != false;
+        }
+
+        return false;
+    }
+
+    public static void SetLastConnectionState(string id, DeviceType type, bool connected)
+    {
+        if (string.IsNullOrEmpty(id))
+            return;
+
+        if (cache == null)
+            cache = new List<TrustedDeviceRecord>();
+
+        var record = cache.FirstOrDefault(r => r.id == id);
+        if (record == null)
+        {
+            record = new TrustedDeviceRecord
+            {
+                id = id,
+                type = type,
+                lastConnected = connected
+            };
+            cache.Add(record);
+        }
+        else
+        {
+            record.type = type;
+            record.lastConnected = connected;
         }
 
         Save();


### PR DESCRIPTION
## Summary
- persist the last connection state for trusted devices, defaulting to auto-reconnect for legacy data
- update BLEManager to honor the stored state, skipping auto-reconnect after user disconnects while recording reconnect intent on new connections

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e648f072f48326921fd213c0e60681