### PR TITLE
Handle iOS BLE permission flow

### DIFF
--- a/BLEUnity/Assets/Scripts/BLEPlugin.cs
+++ b/BLEUnity/Assets/Scripts/BLEPlugin.cs
@@ -25,6 +25,10 @@ public class BLEPlugin : MonoBehaviour
         {
             jc.CallStatic("RequestBlePermissions", gameObject.name, "OnPermissionResult");
         }
+#else
+        // iOS (and other platforms) do not require an explicit runtime Bluetooth permission.
+        // Mark the permission flow as completed so initialization can continue.
+        PermissionGranted = true;
 #endif
     }
 


### PR DESCRIPTION
## Summary
- mark Bluetooth permissions as granted on platforms that do not require a runtime prompt so the native manager initializes on iOS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e784d839ac83269c4228cb92d8e913